### PR TITLE
Make Obscure generic and Secret comparable

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,3 @@
 module github.com/rbranson/camo
 
-go 1.17
-
-require github.com/google/go-cmp v0.5.7
+go 1.21

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,0 @@
-github.com/google/go-cmp v0.5.7 h1:81/ik6ipDQS2aGcBfIN5dHDB36BwrStyeAQquSYCV4o=
-github.com/google/go-cmp v0.5.7/go.mod h1:n+brtR0CgQNWTVd5ZUFpTBC8YFBDLK/h/bpaJ8/DtOE=
-golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
-golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=


### PR DESCRIPTION
This commit uses generics with Obscure and Secret to make them accept both string and byte slice types. It also makes Secret comparable so it may be used as a map key.

The methods Equal and Compare have been dropped. The Equal method is replaced by the == operator. The Compare method is obsoleted by most users not needing to sort obscured secrets.